### PR TITLE
Ensure MySQL is running before granting privileges

### DIFF
--- a/puppet/modules/mysql/manifests/init.pp
+++ b/puppet/modules/mysql/manifests/init.pp
@@ -11,9 +11,9 @@ class mysql {
   exec{ "allow mysql connections from all":
     user => root, group => root,
     command => "/usr/bin/mysql -e \"GRANT ALL PRIVILEGES ON *.* TO 'root'@'%';\"",
-    require => Package["mysql-server"]
+    require => Service["mysql"]
   }
-  
+
   file{ "/etc/mysql/conf.d/custom.cnf":
     mode => 644, owner => root, group => root,
     ensure => file,
@@ -21,5 +21,5 @@ class mysql {
     content => "[mysqld]\nbind-address		= 0.0.0.0\n",
     notify => Service["mysql"]
   }
-  
+
 }


### PR DESCRIPTION
The existing dependency can try to run the GRANT command before MySQL is running.