### PR TITLE
Fix Grid'5000 bug #6693 by adding em-postgresql-adapter gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,7 @@ gem 'syslogger'
 gem 'haml'
 gem 'rack-jsonp'
 gem 'pg', '~> 0.18.0' #as from 0.18.1, requires ruby 1.9.3
-#gem 'em-postgresql-adapter', :git => 'git://github.com/leftbee/em-postgresql-adapter.git', :branch => 'pre-3_1'
+gem 'em-postgresql-adapter', :git => 'git://github.com/leftbee/em-postgresql-adapter.git', :branch => 'pre-3_1'
 
 gem 'blather',
   :git => 'https://github.com/sprsquish/blather.git',


### PR DESCRIPTION
See Bugs/#6693 on Grid5000:
API-Devel servers are down.

In the thin.log:
```
/opt/local/g5k-api/vendor/bundle/ruby/1.9.1/gems/activerecord-3.0.10/lib/active_record/connection_adapters/abstract/connection_specification.rb:71:in `rescue in establish_connection': Please install the em_postgresql adapter: `gem install
 activerecord-em_postgresql-adapter` (no such file to load -- active_record/connection_adapters/em_postgresql_adapter) (RuntimeError)
        from /opt/local/g5k-api/vendor/bundle/ruby/1.9.1/gems/activerecord-3.0.10/lib/active_record/connection_adapters/abstract/connection_specification.rb:68:in `establish_connection'
        from /opt/local/g5k-api/config/initializers/oar.rb:17:in `<top (required)>'
        from /opt/local/g5k-api/vendor/bundle/ruby/1.9.1/gems/activesupport-3.0.10/lib/active_support/dependencies.rb:235:in `load'
        from /opt/local/g5k-api/vendor/bundle/ruby/1.9.1/gems/activesupport-3.0.10/lib/active_support/dependencies.rb:235:in `block in load'
        from /opt/local/g5k-api/vendor/bundle/ruby/1.9.1/gems/activesupport-3.0.10/lib/active_support/dependencies.rb:227:in `load_dependency'
        from /opt/local/g5k-api/vendor/bundle/ruby/1.9.1/gems/activesupport-3.0.10/lib/active_support/dependencies.rb:235:in `load'
        from /opt/local/g5k-api/vendor/bundle/ruby/1.9.1/gems/railties-3.0.10/lib/rails/engine.rb:201:in `block (2 levels) in <class:Engine>'
        from /opt/local/g5k-api/vendor/bundle/ruby/1.9.1/gems/railties-3.0.10/lib/rails/engine.rb:200:in `each'
        from /opt/local/g5k-api/vendor/bundle/ruby/1.9.1/gems/railties-3.0.10/lib/rails/engine.rb:200:in `block in <class:Engine>'
        from /opt/local/g5k-api/vendor/bundle/ruby/1.9.1/gems/railties-3.0.10/lib/rails/initializable.rb:25:in `instance_exec'
        from /opt/local/g5k-api/vendor/bundle/ruby/1.9.1/gems/railties-3.0.10/lib/rails/initializable.rb:25:in `run'
        from /opt/local/g5k-api/vendor/bundle/ruby/1.9.1/gems/railties-3.0.10/lib/rails/initializable.rb:50:in `block in run_initializers'
        from /opt/local/g5k-api/vendor/bundle/ruby/1.9.1/gems/railties-3.0.10/lib/rails/initializable.rb:49:in `each'
        from /opt/local/g5k-api/vendor/bundle/ruby/1.9.1/gems/railties-3.0.10/lib/rails/initializable.rb:49:in `run_initializers'
        from /opt/local/g5k-api/vendor/bundle/ruby/1.9.1/gems/railties-3.0.10/lib/rails/application.rb:134:in `initialize!'
        from /opt/local/g5k-api/vendor/bundle/ruby/1.9.1/gems/railties-3.0.10/lib/rails/application.rb:77:in `method_missing'
        from /opt/local/g5k-api/config/environment.rb:20:in `<top (required)>'
        from /opt/local/g5k-api/config.ru:3:in `require'
        from /opt/local/g5k-api/config.ru:3:in `block in <main>'
        from /opt/local/g5k-api/vendor/bundle/ruby/1.9.1/gems/rack-1.2.4/lib/rack/builder.rb:46:in `instance_eval'
        from /opt/local/g5k-api/vendor/bundle/ruby/1.9.1/gems/rack-1.2.4/lib/rack/builder.rb:46:in `initialize'
        from /opt/local/g5k-api/config.ru:1:in `new'
        from /opt/local/g5k-api/config.ru:1:in `<main>'
        from /opt/local/g5k-api/vendor/bundle/ruby/1.9.1/gems/thin-1.2.11/lib/rack/adapter/loader.rb:36:in `eval'
        from /opt/local/g5k-api/vendor/bundle/ruby/1.9.1/gems/thin-1.2.11/lib/rack/adapter/loader.rb:36:in `load'
        from /opt/local/g5k-api/vendor/bundle/ruby/1.9.1/gems/thin-1.2.11/lib/thin/controllers/controller.rb:181:in `load_rackup_config'
        from /opt/local/g5k-api/vendor/bundle/ruby/1.9.1/gems/thin-1.2.11/lib/thin/controllers/controller.rb:71:in `start'
        from /opt/local/g5k-api/vendor/bundle/ruby/1.9.1/gems/thin-1.2.11/lib/thin/runner.rb:185:in `run_command'
        from /opt/local/g5k-api/vendor/bundle/ruby/1.9.1/gems/thin-1.2.11/lib/thin/runner.rb:151:in `run!'
        from /opt/local/g5k-api/bin/g5k-api.rb:32:in `<top (required)>'
        from <internal:lib/rubygems/custom_require>:29:in `require'
        from <internal:lib/rubygems/custom_require>:29:in `require'
        from /usr/bin/g5k-api:2:in `<main>'
```

In Gemfile of g5k-api I find this commented line.
```
#gem 'em-postgresql-adapter', :git => 'git://github.com/leftbee/em-postgresql-adapter.git', :branch => 'pre-3_1'
```
Maybe need to be uncommented ?