### PR TITLE
bug #7364 - Changed item links in /sites from deployments to deployment …

### DIFF
--- a/app/controllers/sites_controller.rb
+++ b/app/controllers/sites_controller.rb
@@ -61,7 +61,7 @@ class SitesController < ResourcesController
   
   def links_for_item(item)
     links = super(item)
-    %w{jobs vlans metrics}.each do |rel| # abasu bug #7179 removed deployments
+    %w{jobs deployment vlans metrics}.each do |rel| # abasu bug #7364 readded as deployment
       links.push({
         "rel" => rel,
         "type" => media_type(:g5kcollectionjson),

--- a/spec/controllers/sites_controller_spec.rb
+++ b/spec/controllers/sites_controller_spec.rb
@@ -64,8 +64,7 @@ describe SitesController do
       json['uid'].should == 'rennes'
       json['links'].map{|l| l['rel']}.sort.should == [
         "clusters",
-# abasu bug #7179
-#       "deployments",
+        "deployment", # abasu 19.10.2016 - bug #7364 changed "deployments" to "deployment"
         "environments",
         "jobs",
         "metrics",
@@ -84,7 +83,6 @@ describe SitesController do
       }['href'].should == "/sites/rennes/clusters"
       json['links'].find{|l|
         l['rel'] == 'version'
-      # abasu - 24.10.2016 - updated value from 070663579dafada27e078f468614f85a62cf2992
       }['href'].should == "/sites/rennes/versions/2ed3470e0881a22baa43718e62098a0b8dee1e4b"
     end
     
@@ -93,8 +91,7 @@ describe SitesController do
       response.status.should == 200
       json['links'].map{|l| l['rel']}.sort.should == [
         "clusters",
-# abasu bug #7179
-#       "deployments",
+        "deployment", # abasu 19.10.2016 - bug #7364 changed "deployments" to "deployment"
         "environments",
         "jobs",
         "metrics",
@@ -107,6 +104,16 @@ describe SitesController do
         "vlans"
       ]
     end
+    
+    # abasu 19.10.2016 - bug #7364 changed "deployments" to "deployment"
+    it "should return link for deployment" do
+      get :show, :id => "rennes", :format => :json
+      response.status.should == 200
+      json['uid'].should == 'rennes'
+      json['links'].find{|l|
+        l['rel'] == 'deployment'
+      }['href'].should == "/sites/rennes/deployment"
+    end # it "should return link for deployment" do
     
     it "should return the specified version, and the max-age value in the Cache-Control header should be big" do
       get :show, :id => "rennes", :format => :json, :version => "b00bd30bf69c322ffe9aca7a9f6e3be0f29e20f4"


### PR DESCRIPTION
Changed item links in /sites from deployments to deployment to coincide with v4.0 of g5k-api. 
Added spec test to verify.