### PR TITLE
Added spec test to check for link /servers for sites containing servers

### DIFF
--- a/spec/controllers/sites_controller_spec.rb
+++ b/spec/controllers/sites_controller_spec.rb
@@ -115,6 +115,16 @@ describe SitesController do
       }['href'].should == "/sites/rennes/deployment"
     end # it "should return link for deployment" do
     
+    # abasu 26.10.2016 - bug #7301 should return link /servers if present in site
+    it "should return link /servers if present in site" do
+      get :show, :id => "nancy", :format => :json
+      response.status.should == 200
+      json['uid'].should == 'nancy'
+      json['links'].find{|l|
+        l['rel'] == 'servers'
+      }['href'].should == "/sites/nancy/servers"
+    end # it "should return link for deployment" do
+    
     it "should return the specified version, and the max-age value in the Cache-Control header should be big" do
       get :show, :id => "rennes", :format => :json, :version => "b00bd30bf69c322ffe9aca7a9f6e3be0f29e20f4"
       response.status.should == 200

--- a/spec/controllers/sites_controller_spec.rb
+++ b/spec/controllers/sites_controller_spec.rb
@@ -123,7 +123,7 @@ describe SitesController do
       json['links'].find{|l|
         l['rel'] == 'servers'
       }['href'].should == "/sites/nancy/servers"
-    end # it "should return link for deployment" do
+    end # it "should return link /servers if present in site" do
     
     it "should return the specified version, and the max-age value in the Cache-Control header should be big" do
       get :show, :id => "rennes", :format => :json, :version => "b00bd30bf69c322ffe9aca7a9f6e3be0f29e20f4"


### PR DESCRIPTION
Added spec test to check for link /servers for sites containing servers (e.g. nancy in test repository)

Note : The functionality (to create relevant links for servers, if present in a site) was already implemented correctly earlier (PR for bug/#7301)