### PR TITLE
Bug#8489 api root path

### DIFF
--- a/lib/grid5000/router.rb
+++ b/lib/grid5000/router.rb
@@ -14,9 +14,14 @@
 
 module Grid5000
   # Computes the URI to a specific path.
-  # Takes into account the X-Api-Path-Prefix (additional prefix to add to URI
-  # path), and X-Api-Mount-Path (subset of the API path to take out of the URI
-  # path).
+  # X-Api-root-Path is the entry point for all versions of the API
+  # X-Api-version is the version string by which the server is reached
+  # X-Api-Path-Prefix is the entry point to access this service for a
+  #   given version. To use if a server does not wish to show the top level
+  #   hieararchy exposed by the services, for example to only publish the
+  #   resources of a single site (https://rennes.g5k/ ony giving access to
+  #   resources under the /sites/rennes path
+  # X-Api-Mount-Path (subset of the API path to take out of the URI path).
   class Router
     
     def initialize(where)

--- a/lib/grid5000/router.rb
+++ b/lib/grid5000/router.rb
@@ -65,24 +65,21 @@ module Grid5000
         uri = "/" if uri.blank?
         # abasu / dmargery - bug ref 7360 - for correct URI construction
         if in_or_out == :out || relative_or_absolute == :absolute
-	  root_uri=URI(base_uri(in_or_out))
-	  if root_uri.path.blank?
-	    root_path=''
+          root_uri=URI(base_uri(in_or_out))
+          if root_uri.path.blank?
+            root_path=''
           else	
             root_path=root_uri.path+'/'
           end # if root_uri.path.blank?
-
           uri = URI.join(root_uri, root_path+uri).to_s
         end # if in_or_out == :out || relative_or_absolute == :absolute
         uri
       end # def uri_to()
 
-
       # FIXME: move Rails.config to Grid5000.config
       def base_uri(in_or_out = :in)
         Rails.my_config("base_uri_#{in_or_out}".to_sym)
       end # def base_uri()
-
     end
   end
 end

--- a/lib/grid5000/router.rb
+++ b/lib/grid5000/router.rb
@@ -29,6 +29,12 @@ module Grid5000
     
     class << self
       def uri_to(request, path, in_or_out = :in, relative_or_absolute = :relative)
+        root_path = if request.env['HTTP_X_API_ROOT_PATH'].blank?
+          nil
+        else
+          File.join("/", (request.env['HTTP_X_API_ROOT_PATH'] || ""))
+        end # root_path = if request.env['HTTP_X_API_ROOT_PATH'].blank?
+
         api_version = if request.env['HTTP_X_API_VERSION'].blank?
           nil
         else
@@ -47,8 +53,9 @@ module Grid5000
           File.join("/", (request.env['HTTP_X_API_MOUNT_PATH'] || ""))
         end # mount_path = if request.env['HTTP_X_API_MOUNT_PATH'].blank?
 
-        uri = File.join("/", *[api_version, path_prefix, path].compact)
-        uri.gsub!(mount_path, '') unless mount_path.nil?
+        mounted_path=path
+        mounted_path.gsub!(/^#{mount_path}/,'') unless mount_path.nil?
+        uri = File.join("/", *[root_path, api_version, path_prefix, mounted_path].compact)
         uri = "/" if uri.blank?
         # abasu / dmargery - bug ref 7360 - for correct URI construction
         if in_or_out == :out || relative_or_absolute == :absolute

--- a/lib/grid5000/router.rb
+++ b/lib/grid5000/router.rb
@@ -60,6 +60,7 @@ module Grid5000
 
         mounted_path=path
         mounted_path.gsub!(/^#{mount_path}/,'') unless mount_path.nil?
+        mounted_path='/' if mounted_path.blank?
         uri = File.join("/", *[root_path, api_version, path_prefix, mounted_path].compact)
         uri = "/" if uri.blank?
         # abasu / dmargery - bug ref 7360 - for correct URI construction

--- a/spec/controllers/root_controller_spec.rb
+++ b/spec/controllers/root_controller_spec.rb
@@ -39,8 +39,8 @@ describe RootController do
     }
   end
   
-  it "should correcly add the api-prefix if any" do
-    @request.env['HTTP_X_API_PATH_PREFIX'] = 'sid'
+  it "should correcly add the version if any" do
+    @request.env['HTTP_X_API_VERSION'] = 'sid'
     get :show, :id => "grid5000", :format => :json
     response.status.should == 200
     json.should == {

--- a/spec/controllers/sites_controller_spec.rb
+++ b/spec/controllers/sites_controller_spec.rb
@@ -46,7 +46,7 @@ describe SitesController do
       @request.env['HTTP_X_API_MOUNT_PATH'] = '/sites'
       get :index, :format => :json
       response.status.should == 200
-      json['links'].find{|l| l['rel'] == 'self'}['href'].should == "/sid"
+      json['links'].find{|l| l['rel'] == 'self'}['href'].should == "/sid/"
     end
 
   end # describe "GET /sites"


### PR DESCRIPTION
Add support for a X-Api-Root-Path header to support getting requests for the API at urls such as https://proxy.fed4fire.eu/proxies/grid5000

David