### PR TITLE
Bugs/#8542: update our patched version of exhibit.js

### DIFF
--- a/app/views/ui/quick-start.html.haml
+++ b/app/views/ui/quick-start.html.haml
@@ -1,5 +1,5 @@
 - content_for :before_js do
-  %script{:src => "/exhibitv2/exhibit/api/exhibit-api.js?autoCreate=false",
+  %script{:src => relative_path_to("/javascripts/vendor/exhibitv2/exhibit/api/exhibit-api.js")+"?autoCreate=false",
           :type => "text/javascript"}
   %script{:src => relative_path_to("/javascripts/lib/exhibit.js"),
           :type => "text/javascript"}

--- a/config/defaults.yml
+++ b/config/defaults.yml
@@ -33,6 +33,7 @@ development:
   reference_repository_path: ~/reference-repository
   smtp_host: localhost
   smtp_port: 2525
+  127.0.0.1: http
   oar:
     <<: *oar
     host: 127.0.0.1

--- a/lib/grid5000/router.rb
+++ b/lib/grid5000/router.rb
@@ -80,11 +80,13 @@ module Grid5000
       def base_uri(request, in_or_out = :in)
         if request.env.has_key?('HTTP_X_FORWARDED_HOST')
           hosts=request.env['HTTP_X_FORWARDED_HOST'].split(',')
-          frontend=hosts[0]
+          frontend_with_port=hosts[0]
+          frontend=frontend_with_port.split(':').first
           if Rails.my_config(frontend.to_sym)
-            "#{Rails.my_config(frontend.to_sym)}://#{frontend}"
+            "#{Rails.my_config(frontend.to_sym)}://#{frontend_with_port}"
           else
-            "https://#{frontend}"
+            Rails.logger.debug "Did not find configuration entry for #{frontend.to_sym}, extracted from #{hosts}: redirecting to https"
+            "https://#{frontend_with_port}"
           end
         else
           Rails.my_config("base_uri_#{in_or_out}".to_sym)

--- a/public/ui/javascripts/vendor/exhibitv2/ajax/api/simile-ajax-api.js
+++ b/public/ui/javascripts/vendor/exhibitv2/ajax/api/simile-ajax-api.js
@@ -248,7 +248,7 @@ if (typeof SimileAjax == "undefined") {
             ];
             if (!("jQuery" in window) && !("$" in window)) {
 //                javascriptFiles.unshift("jquery-1.4.2.min.js");
-		SimileAjax.includeJavascriptFile(document, "https://api.grid5000.fr/exhibitv2/jquery/1.7.1/jquery.min.js");
+		SimileAjax.includeJavascriptFile(document, "./javascripts/vendor/exhibitv2/jquery/1.7.1/jquery.min.js");
             }
             
 

--- a/public/ui/javascripts/vendor/exhibitv2/exhibit/api/exhibit-api.js
+++ b/public/ui/javascripts/vendor/exhibitv2/exhibit/api/exhibit-api.js
@@ -186,7 +186,7 @@
         }
 
         if (useLocalResources) {
-            Exhibit.urlPrefix = "https://api.grid5000.fr/exhibitv2/exhibit/api/";
+            Exhibit.urlPrefix = "./javascripts/vendor/exhibitv2/exhibit/api/";
         }
 
         if (Exhibit.params.locale) { // ISO-639 language codes,
@@ -268,7 +268,7 @@
         window.SimileAjax_onLoad = loadMe;
 
         var url = useLocalResources ?
-            "https://api.grid5000.fr/exhibitv2/ajax/api/simile-ajax-api.js?bundle=false" :
+            "./javascripts/vendor/exhibitv2/ajax/api/simile-ajax-api.js?bundle=false" :
             "http://api.simile-widgets.org/ajax/2.2.3/simile-ajax-api.js";
 
         var createScriptElement = function() {

--- a/public/ui/javascripts/vendor/exhibitv2/exhibit/api/locales/fr-FR/locale.js
+++ b/public/ui/javascripts/vendor/exhibitv2/exhibit/api/locales/fr-FR/locale.js
@@ -1,0 +1,38 @@
+/*==================================================
+ *  French localization 
+ *==================================================
+ */
+(function() {
+    var isCompiled = ("Exhibit_isCompiled" in window) && window.Exhibit_isCompiled;
+    if (!isCompiled) {
+        var javascriptFiles = [
+            "exhibit-l10n.js",
+            "data/database-l10n.js",
+            "ui/ui-context-l10n.js",
+            "ui/lens-l10n.js",
+            "ui/formatter-l10n.js",
+            "ui/widgets/collection-summary-widget-l10n.js",
+            "ui/views/view-panel-l10n.js",
+            "ui/views/ordered-view-frame-l10n.js",
+            "ui/views/tile-view-l10n.js",
+            "ui/views/thumbnail-view-l10n.js",
+            "ui/views/tabular-view-l10n.js",
+            "util/coders-l10n.js",
+            "util/facets-l10n.js",
+            "util/views-l10n.js"
+        ];
+        var cssFiles = [
+        ];
+
+        var urlPrefix = Exhibit.urlPrefix + "locales/fr/";
+        if (Exhibit.params.bundle) {
+            SimileAjax.includeJavascriptFiles(document, urlPrefix, [ "exhibit-fr-bundle.js" ]);
+            if (cssFiles.length > 0) {
+                SimileAjax.includeCssFiles(document, urlPrefix, [ "exhibit-fr-bundle.css" ]);
+            }
+        } else {
+            SimileAjax.includeJavascriptFiles(document, urlPrefix + "scripts/", javascriptFiles);
+            SimileAjax.includeCssFiles(document, urlPrefix + "styles/", cssFiles);
+        }
+    }
+})();

--- a/puppet/development/modules/apache/manifests/init.pp
+++ b/puppet/development/modules/apache/manifests/init.pp
@@ -18,7 +18,6 @@ class apache {
     'lyon',
     'luxembourg',
     'nancy',
-    'reims',
     'rennes',
     'sophia',
     'nantes'

--- a/puppet/development/modules/apache/templates/api-proxy-dev.erb
+++ b/puppet/development/modules/apache/templates/api-proxy-dev.erb
@@ -47,13 +47,13 @@ Listen 8080
 	<% sites.each_index do |site_index| %>
   <Location /sites/<%= sites[site_index] %>/internal/oarapi>
     RequestHeader set X-Api-Version "sid"
-    RequestHeader set Host "oar-api.<%= sites[site_index] %>.grid5000.fr"
+    RequestHeader set Host "localhost"
     ProxyPreserveHost On
     ProxyPass http://127.0.0.1:880<%= site_index+1 %>/sites/<%= sites[site_index] %>/internal/oarapi retry=0
   </Location>
   <Location /sites/<%= sites[site_index] %>/internal/kadeployapi>
     RequestHeader set X-Api-Version "sid"
-    RequestHeader set Host "kadeploy-devel.<%= sites[site_index] %>.grid5000.fr"
+    RequestHeader set Host "localhost"
     ProxyPreserveHost On
     ProxyPass http://127.0.0.1:880<%= site_index+1 %>/sites/<%= sites[site_index] %>/internal/kadeployapi retry=0
   </Location>

--- a/spec/lib/grid5000/router_spec.rb
+++ b/spec/lib/grid5000/router_spec.rb
@@ -195,6 +195,15 @@ describe Grid5000::Router do
       expect(Rails.my_config(:'from.config')).to eq "http"
       expect(Grid5000::Router.uri_to(request, "/sites/rennes/jobs", :in, :absolute)).to eq "http://from.config/sid/sites/rennes/jobs"
     end
+
+    it "Should allow override of protocol from config file (with explicit port)" do
+      request = double(Rack::MockRequest, :env => {
+        'HTTP_X_API_VERSION' => 'sid',
+        'HTTP_X_FORWARDED_HOST' => "from.config:8080, "+@proxy_header
+      })
+      expect(Rails.my_config(:'from.config')).to eq "http"
+      expect(Grid5000::Router.uri_to(request, "/sites/rennes/jobs", :in, :absolute)).to eq "http://from.config:8080/sid/sites/rennes/jobs"
+    end
   end
 
   it "should take into account the parameters of the config file with empty path" do


### PR DESCRIPTION
Hello,

investigating bug #8542, I discovered we are using a version of exhibit.js that was patched to be able to work from our own servers rather than the public servers publishing the library. 

This might be linked to an old discussion about avoiding warning about getting resources from an http source on an https page. 

This pull request updates the patch to serve the JavaScript files from the assets of g5k-api rather than from https://api.grid5000.fr, in order to be able to use g5k-api's webui through a proxy.

In the process, I fixed issues preventing me from testing my changes:
* an issue with exhibit not being able to decide whether the locale is fr or FR-fr by duplicating a locale.js 
* an issue with the development environment not proxying requests to kadeployapi
* the reference to reims, no longer a Grid'5000 site