### PR TITLE
Add 'X-Api-User-Cn' together with 'X-Remote-Ident' header when callin…

### DIFF
--- a/app/controllers/jobs_controller.rb
+++ b/app/controllers/jobs_controller.rb
@@ -83,6 +83,7 @@ class JobsController < ApplicationController
       :timeout => 5,
       :head => {
         'X-Remote-Ident' => @credentials[:cn],
+        'X-Api-User-Cn' => @credentials[:cn],
         'Accept' => media_type(:json)
       },
       :tls => options
@@ -130,6 +131,7 @@ class JobsController < ApplicationController
       :body => job_to_send.to_json,
       :head => {
         'X-Remote-Ident' => @credentials[:cn],
+        'X-Api-User-Cn' => @credentials[:cn],
         'Content-Type' => media_type(:json),
         'Accept' => media_type(:json)
       },

--- a/spec/controllers/jobs_controller_spec.rb
+++ b/spec/controllers/jobs_controller_spec.rb
@@ -111,7 +111,8 @@ describe JobsController do
           :headers => {
             'Accept' => media_type(:json),
             'Content-Type' => media_type(:json),
-            'X-Remote-Ident' => "crohr"
+            'X-Remote-Ident' => "crohr",
+            'X-Api-User-Cn' => "crohr"
           },
           :body => Grid5000::Job.new(payload).to_hash(:destination => "oar-2.4-submission").to_json
         ).
@@ -136,7 +137,8 @@ describe JobsController do
           :headers => {
             'Accept' => media_type(:json),
             'Content-Type' => media_type(:json),
-            'X-Remote-Ident' => "crohr"
+            'X-Remote-Ident' => "crohr",
+            'X-Api-User-Cn' => "crohr"
           },
           :body => Grid5000::Job.new(payload).to_hash(:destination => "oar-2.4-submission").to_json
         ).
@@ -161,7 +163,8 @@ describe JobsController do
           :headers => {
             'Accept' => media_type(:json),
             'Content-Type' => media_type(:json),
-            'X-Remote-Ident' => "xyz"
+            'X-Remote-Ident' => "xyz",
+            'X-Api-User-Cn' => "xyz"
           },
           :body => Grid5000::Job.new(payload).to_hash(:destination => "oar-2.4-submission").to_json
         ).
@@ -185,7 +188,8 @@ describe JobsController do
           :headers => {
             'Accept' => media_type(:json),
             'Content-Type' => media_type(:json),
-            'X-Remote-Ident' => "crohr"
+            'X-Remote-Ident' => "crohr",
+            'X-Api-User-Cn' => "crohr"
           },
           :body => Grid5000::Job.new(payload).to_hash(:destination => "oar-2.4-submission").to_json
         ).
@@ -215,7 +219,8 @@ describe JobsController do
       @expected_url = "http://api-out.local:80/sites/rennes/internal/oarapi/jobs/#{@job.uid}.json"
       @expected_headers = {
         'Accept' => media_type(:json),
-        'X-Remote-Ident' => @job.user
+        'X-Remote-Ident' => @job.user,
+        'X-Api-User-Cn' => @job.user
       }
     end
 


### PR DESCRIPTION
Add 'X-Api-User-Cn' together with 'X-Remote-Ident' header when calling OAR API, in order to simplify api-proxy configuration when calling OAR API from G5K API.
This commit solves bug 8464.