### PR TITLE
Bug7970 status api performance

### DIFF
--- a/app/controllers/clusters_controller.rb
+++ b/app/controllers/clusters_controller.rb
@@ -26,7 +26,6 @@ class ClustersController < ResourcesController
     result = {
       "uid" => Time.now.to_i,
       "nodes" => OAR::Resource.status(:clusters => params[:id], :network_address => params[:network_address]),
-      "disks" => OAR::Resource.disk_status(:clusters => params[:id], :network_address => params[:network_address]),
       "links" => [
         {
           "rel" => "self",
@@ -40,7 +39,8 @@ class ClustersController < ResourcesController
         }
       ]
     }
-
+    result["disks"] = OAR::Resource.disk_status(:clusters => params[:id], :network_address => params[:network_address]) if params[:disks] != "no"
+    
     respond_to do |format|
       format.g5kitemjson { render :json => result }
       format.json { render :json => result }

--- a/app/controllers/clusters_controller.rb
+++ b/app/controllers/clusters_controller.rb
@@ -25,8 +25,8 @@ class ClustersController < ResourcesController
   def status
     result = {
       "uid" => Time.now.to_i,
-      "nodes" => OAR::Resource.status(:clusters => params[:id]),
-      "disks" => OAR::Resource.disk_status(:clusters => params[:id]),
+      "nodes" => OAR::Resource.status(:clusters => params[:id], :network_address => params[:network_address]),
+      "disks" => OAR::Resource.disk_status(:clusters => params[:id], :network_address => params[:network_address]),
       "links" => [
         {
           "rel" => "self",

--- a/app/controllers/clusters_controller.rb
+++ b/app/controllers/clusters_controller.rb
@@ -25,7 +25,7 @@ class ClustersController < ResourcesController
   def status
     result = {
       "uid" => Time.now.to_i,
-      "nodes" => OAR::Resource.status(:clusters => params[:id], :network_address => params[:network_address]),
+      "nodes" => OAR::Resource.status(:clusters => params[:id], :network_address => params[:network_address], :job_details => params[:job_details]),
       "links" => [
         {
           "rel" => "self",
@@ -39,7 +39,7 @@ class ClustersController < ResourcesController
         }
       ]
     }
-    result["disks"] = OAR::Resource.disk_status(:clusters => params[:id], :network_address => params[:network_address]) if params[:disks] != "no"
+    result["disks"] = OAR::Resource.disk_status(:clusters => params[:id], :network_address => params[:network_address], :job_details => params[:job_details]) if params[:disks] != "no"
     
     respond_to do |format|
       format.g5kitemjson { render :json => result }

--- a/app/controllers/clusters_controller.rb
+++ b/app/controllers/clusters_controller.rb
@@ -25,7 +25,7 @@ class ClustersController < ResourcesController
   def status
     result = {
       "uid" => Time.now.to_i,
-      "nodes" => OAR::Resource.status(:clusters => params[:id], :network_address => params[:network_address], :job_details => params[:job_details]),
+      "nodes" => OAR::Resource.status(:clusters => params[:id], :network_address => params[:network_address], :job_details => params[:job_details], :waiting => params[:waiting]),
       "links" => [
         {
           "rel" => "self",
@@ -39,7 +39,7 @@ class ClustersController < ResourcesController
         }
       ]
     }
-    result["disks"] = OAR::Resource.disk_status(:clusters => params[:id], :network_address => params[:network_address], :job_details => params[:job_details]) if params[:disks] != "no"
+    result["disks"] = OAR::Resource.disk_status(:clusters => params[:id], :network_address => params[:network_address], :job_details => params[:job_details], :waiting => params[:waiting]) if params[:disks] != "no"
     
     respond_to do |format|
       format.g5kitemjson { render :json => result }

--- a/app/controllers/sites_controller.rb
+++ b/app/controllers/sites_controller.rb
@@ -26,7 +26,7 @@ class SitesController < ResourcesController
 
     result = {
       "uid" => Time.now.to_i,
-      "nodes" => OAR::Resource.status(:clusters => valid_clusters, :network_address => params[:network_address]),
+      "nodes" => OAR::Resource.status(:clusters => valid_clusters, :network_address => params[:network_address], :job_details => params[:job_details]),
       "links" => [
         {
           "rel" => "self",
@@ -40,7 +40,7 @@ class SitesController < ResourcesController
         }
       ]
     }
-    result["disks"] = OAR::Resource.disk_status(:clusters => valid_clusters, :network_address => params[:network_address]) if params[:disks] != "no"
+    result["disks"] = OAR::Resource.disk_status(:clusters => valid_clusters, :network_address => params[:network_address], :job_details => params[:job_details]) if params[:disks] != "no"
     
     respond_to do |format|
       format.g5kitemjson { render :json => result }

--- a/app/controllers/sites_controller.rb
+++ b/app/controllers/sites_controller.rb
@@ -26,8 +26,8 @@ class SitesController < ResourcesController
 
     result = {
       "uid" => Time.now.to_i,
-      "nodes" => OAR::Resource.status(:clusters => valid_clusters),
-      "disks" => OAR::Resource.disk_status(:clusters => valid_clusters),
+      "nodes" => OAR::Resource.status(:clusters => valid_clusters, :network_address => params[:network_address]),
+      "disks" => OAR::Resource.disk_status(:clusters => valid_clusters, :network_address => params[:network_address]),
       "links" => [
         {
           "rel" => "self",

--- a/app/controllers/sites_controller.rb
+++ b/app/controllers/sites_controller.rb
@@ -27,7 +27,6 @@ class SitesController < ResourcesController
     result = {
       "uid" => Time.now.to_i,
       "nodes" => OAR::Resource.status(:clusters => valid_clusters, :network_address => params[:network_address]),
-      "disks" => OAR::Resource.disk_status(:clusters => valid_clusters, :network_address => params[:network_address]),
       "links" => [
         {
           "rel" => "self",
@@ -41,6 +40,8 @@ class SitesController < ResourcesController
         }
       ]
     }
+    result["disks"] = OAR::Resource.disk_status(:clusters => valid_clusters, :network_address => params[:network_address]) if params[:disks] != "no"
+    
     respond_to do |format|
       format.g5kitemjson { render :json => result }
       format.json { render :json => result }

--- a/app/controllers/sites_controller.rb
+++ b/app/controllers/sites_controller.rb
@@ -26,7 +26,7 @@ class SitesController < ResourcesController
 
     result = {
       "uid" => Time.now.to_i,
-      "nodes" => OAR::Resource.status(:clusters => valid_clusters, :network_address => params[:network_address], :job_details => params[:job_details]),
+      "nodes" => OAR::Resource.status(:clusters => valid_clusters, :network_address => params[:network_address], :job_details => params[:job_details], :waiting => params[:waiting]),
       "links" => [
         {
           "rel" => "self",
@@ -40,7 +40,7 @@ class SitesController < ResourcesController
         }
       ]
     }
-    result["disks"] = OAR::Resource.disk_status(:clusters => valid_clusters, :network_address => params[:network_address], :job_details => params[:job_details]) if params[:disks] != "no"
+    result["disks"] = OAR::Resource.disk_status(:clusters => valid_clusters, :network_address => params[:network_address], :job_details => params[:job_details], :waiting => params[:waiting]) if params[:disks] != "no"
     
     respond_to do |format|
       format.g5kitemjson { render :json => result }

--- a/lib/oar/job.rb
+++ b/lib/oar/job.rb
@@ -204,6 +204,10 @@ module OAR
         where("state IN ('Waiting','Hold','toLaunch','toError','toAckReservation','Launching','Running','Suspended','Resuming','Finishing')")
       end # def active
 
+      def active_not_waiting
+        where("state IN ('Hold','toLaunch','toError','toAckReservation','Launching','Running','Suspended','Resuming','Finishing')")
+      end # def active_not_waiting
+      
       def expanded
         Job.select("jobs.*, moldable_job_descriptions.moldable_walltime AS walltime, gantt_jobs_predictions.start_time AS predicted_start_time,  moldable_job_descriptions.moldable_id").
           joins("LEFT OUTER JOIN moldable_job_descriptions ON jobs.job_id = moldable_job_descriptions.moldable_job_id").

--- a/lib/oar/resource.rb
+++ b/lib/oar/resource.rb
@@ -60,14 +60,19 @@ module OAR
           "resource_id, cluster, network_address, core, state, available_upto#{include_comment ? ", comment" : ""}"
         )
 
-        # Remove blank network addresses
-        resources = resources.where("network_address <> ''")
+        resources = resources.where(
+          :network_address => options[:network_address]
+        ) unless options[:network_address].blank?
 
         resources = resources.where(
           :cluster => options[:clusters]
         ) unless options[:clusters].blank?
-        resources = resources.index_by(&:resource_id)
 
+        # Remove blank network addresses
+        resources = resources.where("network_address <> ''")
+
+        resources = resources.index_by(&:resource_id)
+        
  	# abasu : Introduce a hash table to store counts of free / busy cores per node - 05.02.2015
         # abasu : This hash table can be used to store other counters in future (add another element)
         nodes_counter = {}
@@ -77,7 +82,7 @@ module OAR
 	  nodes_counter[resource.network_address]= {
                 :totalcores => 0,
                 :busycounter => 0,
-                :besteffortcounter => 0 
+                :besteffortcounter => 0
               } if !nodes_counter.has_key?(resource.network_address)
           if !resource.core.zero?
             # core=0 for non default type of resources
@@ -225,14 +230,21 @@ module OAR
           "resource_id, cluster, host, disk, diskpath"
         )
 
+        # Column host of a disk resource is equal to column
+        # network_address of the node it belongs to
+        resources = resources.where(
+          :host => options[:network_address]
+        ) unless options[:network_address].blank?
+
+        resources = resources.where(
+          :cluster => options[:clusters]
+        ) unless options[:clusters].blank?
+
         # Keep only disks
         resources = resources.where(
           :type => 'disk'
         )
 
-        resources = resources.where(
-          :cluster => options[:clusters]
-        ) unless options[:clusters].blank?
         resources = resources.index_by(&:resource_id)
 
         get_active_jobs_by_moldable_id().each do |moldable_id, h|

--- a/lib/oar/resource.rb
+++ b/lib/oar/resource.rb
@@ -90,7 +90,7 @@ module OAR
           end
 	end  #  .each do |resource_id, resource|
 
-        get_active_jobs_by_moldable_id().each do |moldable_id, h|
+        get_active_jobs_by_moldable_id(options).each do |moldable_id, h|
           current = h[:job].running?
 
           # prepare job description now, since it will be added to each resource
@@ -151,9 +151,10 @@ module OAR
         result
       end # def status
 
-      def get_active_jobs_by_moldable_id()
+      def get_active_jobs_by_moldable_id(options = {})
         active_jobs_by_moldable_id = {}
-        Job.expanded.active.
+        jobs = options[:waiting] == 'no' ? Job.expanded.active_not_waiting : Job.expanded.active
+        jobs.
           find(:all, :include => [:job_types]).
           each{|job|
           active_jobs_by_moldable_id[job.moldable_id] = {
@@ -248,7 +249,7 @@ module OAR
 
         resources = resources.index_by(&:resource_id)
 
-        get_active_jobs_by_moldable_id().each do |moldable_id, h|
+        get_active_jobs_by_moldable_id(options).each do |moldable_id, h|
           current = h[:job].running?
 
           # prepare job description now, since it will be added to each resource

--- a/puppet/development/modules/apt/manifests/init.pp
+++ b/puppet/development/modules/apt/manifests/init.pp
@@ -6,13 +6,13 @@ class apt {
   exec { "sources update":
       command => "apt-get update",
       path => "/usr/bin:/usr/sbin:/bin",
-      #refreshonly => true;
   }
-  
+
   exec { "Box upgrade":
-      command => "apt-get -y upgrade",
+      command => "apt-get -yq upgrade",
+      environment => ["DEBIAN_FRONTEND=noninteractive"],
       path => "/usr/bin:/usr/sbin:/bin:/usr/local/sbin:/sbin",
-      #refreshonly => true;
+      timeout => 900;
   }
 
 }

--- a/spec/controllers/clusters_controller_spec.rb
+++ b/spec/controllers/clusters_controller_spec.rb
@@ -61,6 +61,17 @@ describe ClustersController do
       expect(json['disks']['sdb.parasilo-5.rennes.grid5000.fr']['reservations']).to be_nil
     end # "should return the status of nodes without the reservations"
 
+    # GET /sites/{{site_id}}/clusters/{{id}}/status?waiting=no
+    it "should not return the reservations in Waiting state" do      
+      get :status, :site_id => "rennes", :id => "parasilo", :waiting => "no", :format => :json
+      expect(response.status).to eq 200
+      assert_media_type(:json)
+      expect(json['nodes'].keys.map{|k| k.split('-')[0]}.uniq.sort).to eq ['parasilo']
+      expect(json['disks']).not_to be_nil
+      expect(json['nodes']['parasilo-5.rennes.grid5000.fr']['reservations']).to be_empty
+      expect(json['disks']['sdb.parasilo-5.rennes.grid5000.fr']['reservations']).to be_empty
+    end # "should not return the reservations of nodes in Waiting state"
+
     it "should return all nodes in the specified cluster for which the status is requested" do      
       get :status, :site_id => "rennes", :id => "parapluie", :format => :json
       expect(response.status).to eq 200

--- a/spec/controllers/clusters_controller_spec.rb
+++ b/spec/controllers/clusters_controller_spec.rb
@@ -40,6 +40,16 @@ describe ClustersController do
       expect(json['disks']['sdb.parasilo-5.rennes.grid5000.fr']['reservations']).not_to be_empty
     end # "should return the status ONLY for the specified node"
 
+    # GET /sites/{{site_id}}/clusters/{{id}}/status?disks=no
+    it "should return the status of nodes but not disks" do      
+      get :status, :site_id => "rennes", :id => "parasilo", :disks => "no", :format => :json
+      expect(response.status).to eq 200
+      assert_media_type(:json)
+      expect(json['nodes'].keys.map{|k| k.split('-')[0]}.uniq.sort).to eq ['parasilo']
+      expect(json['disks']).to be_nil
+      expect(json['nodes']['parasilo-5.rennes.grid5000.fr']['reservations']).not_to be_empty
+    end # "should return the status of nodes but not disks"
+
     it "should return all nodes in the specified cluster for which the status is requested" do      
       get :status, :site_id => "rennes", :id => "parapluie", :format => :json
       expect(response.status).to eq 200

--- a/spec/controllers/clusters_controller_spec.rb
+++ b/spec/controllers/clusters_controller_spec.rb
@@ -18,12 +18,27 @@ describe ClustersController do
   render_views
 
   describe "GET /sites/{{site_id}}/clusters/{{id}}/status" do
+    
     it "should return the status ONLY for the specified cluster" do      
-      get :status, :site_id => "rennes", :id => "parapluie", :format => :json
+      get :status, :site_id => "rennes", :id => "parasilo", :format => :json
       expect(response.status).to eq 200
       assert_media_type(:json)
-      expect(json['nodes'].keys.map{|k| k.split('-')[0]}.uniq.sort).to eq ['parapluie']
+      expect(json['nodes'].keys.map{|k| k.split('-')[0]}.uniq.sort).to eq ['parasilo']
+      expect(json['disks']).not_to be_nil
+      expect(json['nodes']['parasilo-5.rennes.grid5000.fr']['reservations']).not_to be_empty
+      expect(json['disks']['sdb.parasilo-5.rennes.grid5000.fr']['reservations']).not_to be_empty   
     end # "should return the status ONLY for the specified cluster"
+
+    # GET /sites/{{site_id}}/clusters/{{id}}/status?network_address={{network_address}}
+    it "should return the status ONLY for the specified node" do
+      get :status, :site_id => "rennes", :id => "parasilo", :network_address => "parasilo-5.rennes.grid5000.fr", :format => :json
+      expect(response.status).to eq 200
+      assert_media_type(:json)
+      expect(json['nodes'].keys.map{|k| k.split('.')[0]}.uniq.sort).to eq ['parasilo-5']
+      expect(json['disks'].keys.map{|k| k.split('.')[1]}.uniq.sort).to eq ['parasilo-5']
+      expect(json['nodes']['parasilo-5.rennes.grid5000.fr']['reservations']).not_to be_empty
+      expect(json['disks']['sdb.parasilo-5.rennes.grid5000.fr']['reservations']).not_to be_empty
+    end # "should return the status ONLY for the specified node"
 
     it "should return all nodes in the specified cluster for which the status is requested" do      
       get :status, :site_id => "rennes", :id => "parapluie", :format => :json
@@ -53,8 +68,6 @@ describe ClustersController do
     end # "should return the status with the correct links"
 
   end # "GET /sites/{{site_id}}/clusters/{{id}}/status"
-
-
 
   # abasu : unit test for bug ref 6363 to handle filter queues - 08.01.2016
   describe "GET /sites/{{site_id}}/clusters/{{id}}" do

--- a/spec/controllers/clusters_controller_spec.rb
+++ b/spec/controllers/clusters_controller_spec.rb
@@ -50,6 +50,17 @@ describe ClustersController do
       expect(json['nodes']['parasilo-5.rennes.grid5000.fr']['reservations']).not_to be_empty
     end # "should return the status of nodes but not disks"
 
+    # GET /sites/{{site_id}}/clusters/{{id}}/status?job_details=no
+    it "should return the status of nodes without the reservations" do      
+      get :status, :site_id => "rennes", :id => "parasilo", :job_details => "no", :format => :json
+      expect(response.status).to eq 200
+      assert_media_type(:json)
+      expect(json['nodes'].keys.map{|k| k.split('-')[0]}.uniq.sort).to eq ['parasilo']
+      expect(json['disks']).not_to be_nil
+      expect(json['nodes']['parasilo-5.rennes.grid5000.fr']['reservations']).to be_nil
+      expect(json['disks']['sdb.parasilo-5.rennes.grid5000.fr']['reservations']).to be_nil
+    end # "should return the status of nodes without the reservations"
+
     it "should return all nodes in the specified cluster for which the status is requested" do      
       get :status, :site_id => "rennes", :id => "parapluie", :format => :json
       expect(response.status).to eq 200

--- a/spec/controllers/sites_controller_spec.rb
+++ b/spec/controllers/sites_controller_spec.rb
@@ -175,6 +175,20 @@ describe SitesController do
       expect(json['nodes']['paramount-4.rennes.grid5000.fr']['reservations']).not_to be_nil
     end
 
+    # GET /sites/{{site_id}}/status?job_details=no
+    it "should return the status without the reservations" do      
+      get :status, :id => "rennes", :job_details => "no", :format => :json
+      expect(response.status).to eq 200
+      expect(json['nodes'].length).to eq 196
+      expect(json['nodes'].keys.map{|k| k.split('-')[0]}.uniq.sort).to eq [
+        'paraquad',
+        'paramount',
+        'paravent'
+      ].sort
+      expect(json['disks']).to be_empty
+      expect(json['nodes']['paramount-4.rennes.grid5000.fr']['reservations']).to be_nil
+    end
+
     # it "should fail if the site does not exist" do
     #   pending "this will be taken care of at the api-proxy layer"
     # end

--- a/spec/controllers/sites_controller_spec.rb
+++ b/spec/controllers/sites_controller_spec.rb
@@ -161,6 +161,20 @@ describe SitesController do
       expect(json['nodes']['paramount-4.rennes.grid5000.fr']['reservations']).not_to be_nil
     end
 
+    # GET /sites/{{site_id}}/status?disks=no
+    it "should return the status of nodes but not disks" do      
+      get :status, :id => "rennes", :disks => "no", :format => :json
+      expect(response.status).to eq 200
+      expect(json['nodes'].length).to eq 196
+      expect(json['nodes'].keys.map{|k| k.split('-')[0]}.uniq.sort).to eq [
+        'paraquad',
+        'paramount',
+        'paravent'
+      ].sort
+      expect(json['disks']).to be_nil
+      expect(json['nodes']['paramount-4.rennes.grid5000.fr']['reservations']).not_to be_nil
+    end
+
     # it "should fail if the site does not exist" do
     #   pending "this will be taken care of at the api-proxy layer"
     # end

--- a/spec/controllers/sites_controller_spec.rb
+++ b/spec/controllers/sites_controller_spec.rb
@@ -142,14 +142,25 @@ describe SitesController do
     it "should return 200 and the site status" do
       get :status, :id => "rennes", :format => :json
       expect(response.status).to eq 200
-
       expect(json['nodes'].length).to eq 196
       expect(json['nodes'].keys.map{|k| k.split('-')[0]}.uniq.sort).to eq [
         'paraquad',
         'paramount',
         'paravent'
       ].sort
+      expect(json['disks']).to be_empty # no reservable disks on paramount-4
+      expect(json['nodes']['paramount-4.rennes.grid5000.fr']['reservations']).not_to be_nil
     end
+
+    # GET /sites/{{site_id}}/status?network_address={{network_address}}
+    it "should return the status ONLY for the specified node" do      
+      get :status, :id => "rennes", :network_address => "paramount-4.rennes.grid5000.fr", :format => :json
+      expect(response.status).to eq 200
+      expect(json['nodes'].keys.map{|k| k.split('.')[0]}.uniq.sort).to eq ['paramount-4']
+      expect(json['disks']).to be_empty
+      expect(json['nodes']['paramount-4.rennes.grid5000.fr']['reservations']).not_to be_nil
+    end
+
     # it "should fail if the site does not exist" do
     #   pending "this will be taken care of at the api-proxy layer"
     # end

--- a/spec/lib/oar/job_spec.rb
+++ b/spec/lib/oar/job_spec.rb
@@ -43,6 +43,10 @@ describe OAR::Job do
   # abasu -- updated jobs list as new jobs added to test different bugs -- 2015.04.07
   end
 
+  it "should fetch the list of active jobs being not in Waiting state" do
+    expect(OAR::Job.active_not_waiting.map(&:uid)).to eq([374173, 374179, 374180, 374185, 374186, 374190, 374191, 374192, 374193, 374194, 374195, 374196, 374198, 374210])
+  end
+
   # abasu : test introduced below for correction to bug ref 5347 -- 2015.03.09
   it "should fetch the job with the jobid AND match all job parameters" do
     params = {

--- a/spec/lib/oar/resource_spec.rb
+++ b/spec/lib/oar/resource_spec.rb
@@ -71,6 +71,10 @@ describe OAR::Resource do
     expect(OAR::Resource.status(:job_details => 'no').map{ |e| e[1]['reservations'] }.compact).to be_empty
   end
 
+  it "should not return the reservations in Waiting state" do
+    expect(OAR::Resource.status(:waiting => 'no', :network_address => 'parasilo-5.rennes.grid5000.fr').first[1]['reservations']).to be_nil
+  end
+
   # abasu : test added to check new status values -- bug ref 5106
   it "should return a node with status free_busy" do
     expect(OAR::Resource.status.select do |node, status|

--- a/spec/lib/oar/resource_spec.rb
+++ b/spec/lib/oar/resource_spec.rb
@@ -67,6 +67,10 @@ describe OAR::Resource do
       map{|n| n.split(".")[0]}.uniq.sort).to eq ['parasilo-1']
   end
 
+  it "should not return the reservations" do
+    expect(OAR::Resource.status(:job_details => 'no').map{ |e| e[1]['reservations'] }.compact).to be_empty
+  end
+
   # abasu : test added to check new status values -- bug ref 5106
   it "should return a node with status free_busy" do
     expect(OAR::Resource.status.select do |node, status|

--- a/spec/lib/oar/resource_spec.rb
+++ b/spec/lib/oar/resource_spec.rb
@@ -61,7 +61,12 @@ describe OAR::Resource do
     expect(OAR::Resource.status(:clusters => ['paradent', 'paramount']).keys.
       map{|n| n.split("-")[0]}.uniq.sort).to eq ['paradent', 'paramount']
   end
-  
+
+  it "should return the status only for the resources belonging to the given node" do
+    expect(OAR::Resource.status(:network_address => 'parasilo-1.rennes.grid5000.fr').keys.
+      map{|n| n.split(".")[0]}.uniq.sort).to eq ['parasilo-1']
+  end
+
   # abasu : test added to check new status values -- bug ref 5106
   it "should return a node with status free_busy" do
     expect(OAR::Resource.status.select do |node, status|


### PR DESCRIPTION
This pull request adds several query strings to the status API. The aim is to retrieve less information, from a single node (specified by its network address), in order to speed up g5k-api response time.